### PR TITLE
Forecast api

### DIFF
--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::ForecastController < ApplicationController
+  def index
+    data = ForecastFacade.all_weather(params[:location])
+    render json: ForecastSerializer.format(data)
+  end
+end

--- a/app/facades/forecast_facade.rb
+++ b/app/facades/forecast_facade.rb
@@ -1,0 +1,9 @@
+class ForecastFacade
+  def self.all_weather(location)
+    data = ForecastService.get_coordinates(location)
+    latitude = data[:results][0][:locations][0][:latLng][:lat]
+    longitude = data[:results][0][:locations][0][:latLng][:lng]
+
+    forecast_data = ForecastService.get_forecast(latitude, longitude)
+  end
+end

--- a/app/facades/forecast_facade.rb
+++ b/app/facades/forecast_facade.rb
@@ -3,7 +3,6 @@ class ForecastFacade
     data = ForecastService.get_coordinates(location)
     latitude = data[:results][0][:locations][0][:latLng][:lat]
     longitude = data[:results][0][:locations][0][:latLng][:lng]
-
     forecast_data = ForecastService.get_forecast(latitude, longitude)
   end
 end

--- a/app/poros/forecast.rb
+++ b/app/poros/forecast.rb
@@ -1,0 +1,6 @@
+class Forecast
+  def initialize(data)
+    
+    require 'pry'; binding.pry
+  end
+end

--- a/app/serializer/forecast_serializer.rb
+++ b/app/serializer/forecast_serializer.rb
@@ -1,0 +1,54 @@
+class ForecastSerializer
+  include JSONAPI::Serializer
+
+  def self.format(data)
+    # require 'pry'; binding.pry
+    test = {
+      "data": {
+        "id": nil,
+        "type": "forecast",
+        "attributes": {
+          "current_weather": {
+            "datetime": Time.at(data[:current][:dt]),
+            "sunrise": Time.at(data[:current][:sunrise]),
+            "sunset": Time.at(data[:current][:sunset]),
+            "temperature": data[:current][:temp],
+            "feels_like": data[:current][:feels_like],
+            "humidity": data[:current][:humidity],
+            "uvi": data[:current][:uvi],
+            "visibility": data[:current][:visibility],
+            "conditions": data[:current][:weather][0][:main],
+            "icon": data[:current][:weather][0][:icon]
+          },
+          "daily_weather": daily_weather(data),
+          "hourly_weather": hourly_weather(data)
+        }
+      }
+    }
+  end
+
+  def self.daily_weather(data)
+    data[:daily].slice(0, 5).map do |daily_weather|
+      {
+        "date": Time.at(daily_weather[:dt]).to_date,
+        "sunrise": Time.at(daily_weather[:dt]),
+        "sunset": Time.at(daily_weather[:dt]),
+        "max_temp": daily_weather[:temp][:max],
+        "min_temp": daily_weather[:temp][:min],
+        "conditions": daily_weather[:weather][0][:main],
+        "icon": daily_weather[:weather][0][:icon]
+      }
+    end
+  end
+
+  def self.hourly_weather(data)
+    data[:hourly].slice(0, 8).map do |weather|
+      {
+        "time": Time.at(weather[:dt]).strftime("%I:%m %p"),
+        "temperature": weather[:temp],
+        "conditions": weather[:weather][0][:main],
+        "icon": weather[:weather][0][:icon]
+      }
+    end
+  end
+end

--- a/app/serializer/forecast_serializer.rb
+++ b/app/serializer/forecast_serializer.rb
@@ -2,8 +2,7 @@ class ForecastSerializer
   include JSONAPI::Serializer
 
   def self.format(data)
-    # require 'pry'; binding.pry
-    test = {
+    {
       "data": {
         "id": nil,
         "type": "forecast",

--- a/app/services/forecast_service.rb
+++ b/app/services/forecast_service.rb
@@ -1,0 +1,22 @@
+class ForecastService
+  def self.get_coordinates(location)
+    conn = Faraday.new(url: "http://www.mapquestapi.com",
+      params: { "key": ENV['mapquest_api_key'] }
+    )
+    response = conn.get("/geocoding/v1/address?location=#{location}")
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def self.get_forecast(lat, lon)
+    conn = Faraday.new(url: "https://api.openweathermap.org") do |faraday|
+      faraday.params[:lat] = lat
+      faraday.params[:lon] = lon
+      faraday.params[:exclude] = "minutely"
+      faraday.params[:units] = "imperial"
+      faraday.params[:appid] = ENV['forecast_api_key']
+    end
+    response = conn.get("/data/2.5/onecall")
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/backgrounds', to: 'backgrounds#index'
+      get '/forecast', to: 'forecast#index'
     end
   end
 end

--- a/spec/api/v1/forecast_request_spec.rb
+++ b/spec/api/v1/forecast_request_spec.rb
@@ -6,7 +6,40 @@ RSpec.describe 'Forecast API' do
       location = "Breckenridge"
       get "/api/v1/forecast?location=#{location}"
       something = JSON.parse(response.body, symbolize_names: true)
-      require 'pry'; binding.pry
+
+      expect(something).to have_key(:data)
+      expect(something[:data]).to have_key(:id)
+      expect(something[:data]).to have_key(:type)
+      expect(something[:data]).to have_key(:attributes)
+      expect(something[:data][:attributes][:current_weather]).to have_key(:datetime)
+      expect(something[:data][:attributes][:current_weather]).to have_key(:sunrise)
+      expect(something[:data][:attributes][:current_weather]).to have_key(:sunset)
+      expect(something[:data][:attributes][:current_weather]).to have_key(:temperature)
+      expect(something[:data][:attributes][:current_weather]).to have_key(:feels_like)
+      expect(something[:data][:attributes][:current_weather]).to have_key(:humidity)
+      expect(something[:data][:attributes][:current_weather]).to have_key(:uvi)
+      expect(something[:data][:attributes][:current_weather]).to have_key(:visibility)
+      expect(something[:data][:attributes][:current_weather]).to have_key(:conditions)
+      expect(something[:data][:attributes][:current_weather]).to have_key(:icon)
+
+      expect(something[:data][:attributes][:daily_weather].count).to eq(5)
+      something[:data][:attributes][:daily_weather].each do |weather|
+        expect(weather).to have_key(:date)
+        expect(weather).to have_key(:sunrise)
+        expect(weather).to have_key(:sunset)
+        expect(weather).to have_key(:max_temp)
+        expect(weather).to have_key(:min_temp)
+        expect(weather).to have_key(:conditions)
+        expect(weather).to have_key(:icon)
+      end
+
+      expect(something[:data][:attributes][:hourly_weather].count).to eq(8)
+      something[:data][:attributes][:hourly_weather].each do |weather|
+        expect(weather).to have_key(:time)
+        expect(weather).to have_key(:temperature)
+        expect(weather).to have_key(:conditions)
+        expect(weather).to have_key(:icon)
+      end
     end
   end
 end

--- a/spec/api/v1/forecast_request_spec.rb
+++ b/spec/api/v1/forecast_request_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe 'Forecast API' do
+  describe 'GET /forecast?location=location' do
+    it 'returns the forecast information based on the location provided' do
+      location = "Breckenridge"
+      get "/api/v1/forecast?location=#{location}"
+      something = JSON.parse(response.body, symbolize_names: true)
+      require 'pry'; binding.pry
+    end
+  end
+end

--- a/spec/facades/forecast_facade_spec.rb
+++ b/spec/facades/forecast_facade_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ForecastFacade do
       expect(data[:current]).to have_key(:humidity)
       expect(data[:current]).to have_key(:uvi)
       expect(data[:current]).to have_key(:visibility)
-      expect(data[:current][:weather][0]).to have_key(:description)
+      expect(data[:current][:weather][0]).to have_key(:main)
       expect(data[:current][:weather][0]).to have_key(:icon)
 
 

--- a/spec/facades/forecast_facade_spec.rb
+++ b/spec/facades/forecast_facade_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe ForecastFacade do
+  describe '::all_weather' do
+    it 'returns all the weather from the one call api endpoint' do
+      data = ForecastFacade.all_weather("denver,co")
+
+      expect(data[:lat]).to eq(39.7385)
+      expect(data[:lon]).to eq(-104.9849)
+      expect(data[:current]).to have_key(:dt)
+      expect(data[:current]).to have_key(:sunrise)
+      expect(data[:current]).to have_key(:sunset)
+      expect(data[:current]).to have_key(:temp)
+      expect(data[:current]).to have_key(:feels_like)
+      expect(data[:current]).to have_key(:humidity)
+      expect(data[:current]).to have_key(:uvi)
+      expect(data[:current]).to have_key(:visibility)
+      expect(data[:current][:weather][0]).to have_key(:description)
+      expect(data[:current][:weather][0]).to have_key(:icon)
+
+
+      # require 'pry'; binding.pry
+    end
+  end
+end


### PR DESCRIPTION
This PR: 

- Consumes the mapquest geocoordinate api endpoint
- Consumes the OpenWeather One Call Api endpoint
- Exposes a new endpoint with reformatted weather that is relevant to the frontend `GET /api/v1/forecast?location=denver,co`

