### PR TITLE
Register user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'puma', '~> 3.11'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
@@ -40,6 +40,7 @@ group :development, :test do
   gem 'capybara'
   gem 'factory_bot_rails'
   gem 'rspec-rails'
+  gem 'shoulda-matchers'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
+    bcrypt (3.1.16)
     bootsnap (1.10.3)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -160,6 +161,8 @@ GEM
     rspec-support (3.11.0)
     ruby2_keywords (0.0.5)
     ruby_dep (1.5.0)
+    shoulda-matchers (5.1.0)
+      activesupport (>= 5.2.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -191,6 +194,7 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   byebug
   capybara
@@ -205,6 +209,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.6, >= 5.2.6.2)
   rspec-rails
+  shoulda-matchers
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,14 @@
+class Api::V1::UsersController < ApplicationController
+  def create
+    user = User.create(user_params)
+    if user.save
+      session[:user_id] = user.id
+    end
+  end
+
+  private
+
+  def user_params
+    params.permit(:email, :password, :password_confirmation)
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,12 +3,17 @@ class Api::V1::UsersController < ApplicationController
     user = User.create(user_params)
     if user.save
       session[:user_id] = user.id
+      render json: UsersSerializer.send_token(user), status: 201
+    elsif User.find_by(email: params[:email])
+      render json: UsersSerializer.error("This email already exists!"), status: 400
+    elsif params[:password] != params[:password_confirmation]
+      render json: UsersSerializer.error("Your passwords must match!"), status: 400
     end
   end
 
   private
 
   def user_params
-    params.permit(:email, :password, :password_confirmation)
+    params.permit(:email, :password, :password_confirmation, :auth_token)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,5 @@ class User < ApplicationRecord
   validates :email, :password_digest, presence: true
   validates :email, uniqueness: true
   has_secure_password
+  has_secure_token :auth_token
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,5 @@
+class User < ApplicationRecord
+  validates :email, :password_digest, presence: true
+  validates :email, uniqueness: true
+  has_secure_password
+end

--- a/app/serializer/users_serializer.rb
+++ b/app/serializer/users_serializer.rb
@@ -1,0 +1,22 @@
+class UsersSerializer
+  include JSONAPI::Serializer
+
+  def self.send_token(user)
+    {
+      "data": {
+        "type": "users",
+        "id": user.id,
+        "attributes": {
+          "email": user.email,
+          "api_key": user.auth_token
+        }
+      }
+    }
+  end
+
+  def self.error(message)
+    {
+      "error": message
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
+      resources :users, only: [:create]
       get '/backgrounds', to: 'backgrounds#index'
       get '/forecast', to: 'forecast#index'
     end

--- a/db/migrate/20220305031247_create_user.rb
+++ b/db/migrate/20220305031247_create_user.rb
@@ -1,0 +1,10 @@
+class CreateUser < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220305051953_add_auth_token_to_user.rb
+++ b/db/migrate/20220305051953_add_auth_token_to_user.rb
@@ -1,0 +1,6 @@
+class AddAuthTokenToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :auth_token, :string
+    add_index :users, :auth_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2022_03_05_031247) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_05_031247) do
+ActiveRecord::Schema.define(version: 2022_03_05_051953) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 2022_03_05_031247) do
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "auth_token"
+    t.index ["auth_token"], name: "index_users_on_auth_token", unique: true
   end
 
 end

--- a/spec/api/v1/user_request_spec.rb
+++ b/spec/api/v1/user_request_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'User API Endpoint' do
+  describe 'POST /users' do
+    it 'creates a new user in the database' do
+      user_params = { email: 'joe@shmo.com', password: '12345', password_confirmation: '12345'}
+      post '/api/v1/users', params: user_params
+      created_user = User.last
+
+      expect(User.last.email).to eq(user_params[:email])
+    end
+  end
+end

--- a/spec/api/v1/user_request_spec.rb
+++ b/spec/api/v1/user_request_spec.rb
@@ -5,9 +5,27 @@ RSpec.describe 'User API Endpoint' do
     it 'creates a new user in the database' do
       user_params = { email: 'joe@shmo.com', password: '12345', password_confirmation: '12345'}
       post '/api/v1/users', params: user_params
-      created_user = User.last
+
+      result = JSON.parse(response.body, symbolize_names: true)
 
       expect(User.last.email).to eq(user_params[:email])
+      expect(result).to have_key(:data)
+      expect(result[:data]).to have_key(:type)
+      expect(result[:data]).to have_key(:id)
+      expect(result[:data]).to have_key(:attributes)
+      expect(result[:data][:attributes]).to have_key(:email)
+      expect(result[:data][:attributes]).to have_key(:api_key)
+    end
+
+    it 'doesnt allow the same email to be used more than once' do
+      user_params = { email: 'joe@shmo.com', password: '12345', password_confirmation: '12345'}
+      post '/api/v1/users', params: user_params
+      # Sad path
+      # Tries to recreate the same user
+      post '/api/v1/users', params: user_params
+      result = JSON.parse(response.body, symbolize_names: true)
+      expect(User.all.count).to eq(1)
+      expect(result[:error]).to eq("This email already exists!")
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe User do
+  it { should validate_presence_of(:username) }
+  it { should validate_uniqueness_of(:username) }
+  it { should validate_presence_of(:password_digest) }
+  it { should have_secure_password }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe User do
-  it { should validate_presence_of(:username) }
-  it { should validate_uniqueness_of(:username) }
-  it { should validate_presence_of(:password_digest) }
-  it { should have_secure_password }
+  describe 'validations' do
+    it { should validate_presence_of(:email) }
+    it { should validate_uniqueness_of(:email) }
+    it { should validate_presence_of(:password_digest) }
+    it { should have_secure_password }
+
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,9 +2,8 @@ require 'rails_helper'
 
 RSpec.describe User do
   describe 'validations' do
-    # it { should have_secure_token }
+    it { should have_secure_token(:auth_token) }
     it { should validate_presence_of(:email) }
-    # it { should validate_uniqueness_of(:token) }
     it { should validate_uniqueness_of(:email) }
     it { should validate_presence_of(:password_digest) }
     it { should have_secure_password }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 RSpec.describe User do
   describe 'validations' do
+    # it { should have_secure_token }
     it { should validate_presence_of(:email) }
+    # it { should validate_uniqueness_of(:token) }
     it { should validate_uniqueness_of(:email) }
     it { should validate_presence_of(:password_digest) }
     it { should have_secure_password }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,6 +6,5 @@ RSpec.describe User do
     it { should validate_uniqueness_of(:email) }
     it { should validate_presence_of(:password_digest) }
     it { should have_secure_password }
-
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,3 +64,10 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
This PR:

- Adds the functionality for a user to be created through exposing the endpoint: `POST /api/v1/users`
- Creates an API auth token if the user successfully registers or logs in.
- SAD PATHS:
    - Prevents the user from entering mismatching passwords
    - Prevents the user from registering the same email more than once.
    - Displays the reason for a sad path
